### PR TITLE
Update formula for veracode-cli version 3.4.6

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,26 +1,23 @@
 class VeracodeCli < Formula
-  desc "Veracode CLI for security testing of applications"
+  desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.26.0"
+  version "3.4.6"
   license "MIT"
-
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_macosx_arm64.tar.gz"
-      sha256 "d77b2aa19842b67f4b5a509300b6afbe7c8fbb934afbd932392b1fd457756fb2"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_3.4.6_macosx_arm64.tar.gz"
+      sha256 "610d106180be84c225bb60fb847169d1849407ffaa6bf1daf911ad78c80f2e37"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_macosx_x86.tar.gz"
-      sha256 "68bdf646faeebe0a97e41e83d65c00b7812b87a54b62b3aae865a3b5ca768c0b"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_3.4.6_macosx_x86.tar.gz"
+      sha256 "cfb57621e92551247c2835fad9bc64234b4fea8101af2d222b6e8d60bd10c9fe"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_linux_x86.tar.gz"
-    sha256 "96d76c6cac0d8f4d216131f0a51882f421e1c018a70a189d333dcb1b35638810"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_3.4.6_linux_x86.tar.gz"
+    sha256 "fd0020ea2bdef30cf916cb873cf6e283f42cea0543c4cd5852089136b6732135"
   end
-
   def install
     bin.install "veracode"
   end
-
   test do
     system "#{bin}/veracode", "version"
   end


### PR DESCRIPTION
This PR updates the brew formula to version 3.4.6