### PR TITLE
Update formula for veracode-cli version 4.0.1

### DIFF
--- a/Formula/veracode-cli.rb
+++ b/Formula/veracode-cli.rb
@@ -1,26 +1,23 @@
 class VeracodeCli < Formula
-  desc "Veracode CLI for security testing of applications"
+  desc "Command-line tool for testing application security with Veracode"
   homepage "https://www.veracode.com"
-  version "2.26.0"
+  version "4.0.1"
   license "MIT"
-
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_macosx_arm64.tar.gz"
-      sha256 "d77b2aa19842b67f4b5a509300b6afbe7c8fbb934afbd932392b1fd457756fb2"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_4.0.1_macosx_arm64.tar.gz"
+      sha256 "a92c7e68c14c57574671091be6dbac51900d673d10f2721560f26f354a25782b"
     elsif Hardware::CPU.intel?
-      url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_macosx_x86.tar.gz"
-      sha256 "68bdf646faeebe0a97e41e83d65c00b7812b87a54b62b3aae865a3b5ca768c0b"
+      url "https://tools.veracode.com/veracode-cli/veracode-cli_4.0.1_macosx_x86.tar.gz"
+      sha256 "adabb8a00e59c8f0e0686e9b7b9d0d255f6573f53fdd932102a61e50dd7bbcdc"
     end
   elsif OS.linux?
-    url "https://tools.veracode.com/veracode-cli/veracode-cli_2.26.0_linux_x86.tar.gz"
-    sha256 "96d76c6cac0d8f4d216131f0a51882f421e1c018a70a189d333dcb1b35638810"
+    url "https://tools.veracode.com/veracode-cli/veracode-cli_4.0.1_linux_x86.tar.gz"
+    sha256 "5aa9532d235747f18f8541ce4fa930ff23e699309d32558cd7ae7d240ffceb07"
   end
-
   def install
     bin.install "veracode"
   end
-
   test do
     system "#{bin}/veracode", "version"
   end


### PR DESCRIPTION
This PR updates the brew formula to version 4.0.1